### PR TITLE
Replace python with sed

### DIFF
--- a/3.3-apache/Dockerfile
+++ b/3.3-apache/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update \
       ca-certificates \
       git \
       iproute2 \
-      python \
  && mkdir /opt/owasp-crs \
  && cd /opt/owasp-crs \
  && git init \

--- a/3.3-nginx/Dockerfile
+++ b/3.3-nginx/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update \
       ca-certificates \
       git \
       iproute2 \
-      python \
  && mkdir /opt/owasp-crs \
  && cd /opt/owasp-crs \
  && git init \

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -1,172 +1,87 @@
 #!/bin/bash
 
+set -e
+
 # Paranoia Level
-$(python <<EOF
-import re
-import os
-out=re.sub('(#SecAction[\S\s]{7}id:900000[\s\S]*tx\.paranoia_level=1\")','SecAction \\\\\n  \"id:900000, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:tx.paranoia_level='+os.environ['PARANOIA']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+sed -z -E -i 's/#SecAction.{7}id:900000.*tx\.paranoia_level=1\"/SecAction \\\n  \"id:900000, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.paranoia_level='"$PARANOIA"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf 
 
 # Executing Paranoia Level
-$(python <<EOF
-import re
-import os
-if "EXECUTING_PARANOIA" in os.environ: 
-   out=re.sub('(#SecAction[\S\s]{7}id:900001[\s\S]*tx\.executing_paranoia_level=1\")','SecAction \\\\\n  \"id:900001, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:tx.executing_paranoia_level='+os.environ['EXECUTING_PARANOIA']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $EXECUTING_PARANOIA ]; then
+  sed -z -E -i 's/#SecAction.{7}id:900001.*tx\.executing_paranoia_level=1\"/SecAction \\\n  \"id:900001, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.executing_paranoia_level='"$EXECUTING_PARANOIA"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Enforce Body Processor URLENCODED
-$(python <<EOF
-import re
-import os
-if "ENFORCE_BODYPROC_URLENCODED" in os.environ:
-   out=re.sub('(#SecAction[\S\s]{7}id:900010[\s\S]*tx\.enforce_bodyproc_urlencoded=1\")','SecAction \\\\\n  \"id:900010, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:tx.enforce_bodyproc_urlencoded='+os.environ['ENFORCE_BODYPROC_URLENCODED']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $ENFORCE_BODYPROC_URLENCODED ]; then
+  sed -z -E -i 's/#SecAction.{7}id:900010.*tx\.enforce_bodyproc_urlencoded=1\"/SecAction \\\n  \"id:900010, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.enforce_bodyproc_urlencoded='"$ENFORCE_BODYPROC_URLENCODED"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Inbound and Outbound Anomaly Score
-$(python <<EOF
-import re
-import os
-out=re.sub('(#SecAction[\S\s]{6}id:900110[\s\S]*tx\.outbound_anomaly_score_threshold=4\")','SecAction \\\\\n  \"id:900110, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:tx.inbound_anomaly_score_threshold='+os.environ['ANOMALYIN']+','+'  \\\\\n   setvar:tx.outbound_anomaly_score_threshold='+os.environ['ANOMALYOUT']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+sed -z -E -i 's/#SecAction.{6}id:900110.*tx\.outbound_anomaly_score_threshold=4\"/SecAction \\\n  \"id:900110, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.inbound_anomaly_score_threshold='"$ANOMALYIN"',  \\\n   setvar:tx.outbound_anomaly_score_threshold='"$ANOMALYOUT"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf 
 
 # HTTP methods that a client is allowed to use.
-$(python <<EOF
-import re
-import os
-if "ALLOWED_METHODS" in os.environ:
-   out=re.sub('(#SecAction[\S\s]{6}id:900200[\s\S]*\'tx\.allowed_methods=[A-Z\s]*\'\")','SecAction \\\\\n  \"id:900200, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:\'tx.allowed_methods='+os.environ['ALLOWED_METHODS']+'\'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $ALLOWED_METHODS ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900200.*\x27tx\.allowed_methods=[[:upper:][:space:]]*\x27\"/SecAction \\\n  \"id:900200, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.allowed_methods='"$ALLOWED_METHODS"'\x27\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Content-Types that a client is allowed to send in a request.
-$(python <<EOF
-import re
-import os
-if "ALLOWED_REQUEST_CONTENT_TYPE" in os.environ:
-   out=re.sub('(#SecAction[\S\s]{6}id:900220[\s\S]*\'tx.allowed_request_content_type=[a-z|\-\+\/]*\'\")','SecAction \\\\\n  \"id:900220, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:\'tx.allowed_request_content_type='+os.environ['ALLOWED_REQUEST_CONTENT_TYPE']+'\'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $ALLOWED_REQUEST_CONTENT_TYPE ]; then
+  sed -z -E -i 's;#SecAction.{6}id:900220.*\x27tx\.allowed_request_content_type=[[:lower:]|+/-]*\x27\";SecAction \\\n  \"id:900220, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.allowed_request_content_type='"$ALLOWED_REQUEST_CONTENT_TYPE"'\x27\";' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Content-Types charsets that a client is allowed to send in a request.
-$(python <<EOF
-import re
-import os
-if "ALLOWED_REQUEST_CONTENT_TYPE_CHARSET" in os.environ:
-   out=re.sub('(#SecAction[\S\s]{6}id:900270[\s\S]*\'tx.allowed_request_content_type_charset=[|\-a-z0-9]*\'\")','SecAction \\\\\n  \"id:900270, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:\'tx.allowed_request_content_type_charset='+os.environ['ALLOWED_REQUEST_CONTENT_TYPE_CHARSET']+'\'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $ALLOWED_REQUEST_CONTENT_TYPE_CHARSET ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900270.*\x27tx\.allowed_request_content_type_charset=[[:lower:][:digit:]|-]*\x27\"/SecAction \\\n  \"id:900270, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.allowed_request_content_type_charset='"$ALLOWED_REQUEST_CONTENT_TYPE_CHARSET"'\x27\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Allowed HTTP versions.
-$(python <<EOF
-import re
-import os
-if "ALLOWED_HTTP_VERSIONS" in os.environ:
-   out=re.sub('(#SecAction[\S\s]{6}id:900230[\s\S]*\'tx.allowed_http_versions=[HTP012\/\.\s]*\'\")','SecAction \\\\\n  \"id:900230, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:\'tx.allowed_http_versions='+os.environ['ALLOWED_HTTP_VERSIONS']+'\'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $ALLOWED_HTTP_VERSIONS ]; then
+  sed -z -E -i 's|#SecAction.{6}id:900230.*\x27tx\.allowed_http_versions=[HTP012[:space:]/.]*\x27\"|SecAction \\\n  \"id:900230, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.allowed_http_versions='"$ALLOWED_HTTP_VERSIONS"'\x27\"|' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Forbidden file extensions.
-$(python <<EOF
-import re
-import os
-if "RESTRICTED_EXTENSIONS" in os.environ:
-   out=re.sub('(#SecAction[\S\s]{6}id:900240[\s\S]*\'tx.restricted_extensions=[\.a-z\s\/]*\/\'\")','SecAction \\\\\n  \"id:900240, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:\'tx.restricted_extensions='+os.environ['RESTRICTED_EXTENSIONS']+'\'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $RESTRICTED_EXTENSIONS ]; then
+  sed -z -E -i 's|#SecAction.{6}id:900240.*\x27tx\.restricted_extensions=[[:lower:][:space:]./]*\/\x27\"|SecAction \\\n  \"id:900240, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.restricted_extensions='"$RESTRICTED_EXTENSIONS"'\x27\"|' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Forbidden request headers.
-$(python <<EOF
-import re
-import os
-if "RESTRICTED_HEADERS" in os.environ:
-   out=re.sub('(#SecAction[\S\s]{6}id:900250[\s\S]*\'tx.restricted_headers=[a-z\s\/\-]*\'\")','SecAction \\\\\n  \"id:900250, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:\'tx.restricted_headers='+os.environ['RESTRICTED_HEADERS']+'\'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $RESTRICTED_HEADERS ]; then
+  sed -z -E -i 's|#SecAction.{6}id:900250.*\x27tx\.restricted_headers=[[:lower:][:space:]/-]*\x27\"|SecAction \\\n  \"id:900250, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.restricted_headers='"$RESTRICTED_HEADERS"'\x27\"|' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # File extensions considered static files.
-$(python <<EOF
-import re
-import os
-if "STATIC_EXTENSIONS" in os.environ:
-   out=re.sub('(#SecAction[\S\s]{6}id:900260[\s\S]*\'tx.static_extensions=\/[a-z\s\/\.]*\'\")','SecAction \\\\\n  \"id:900260, \\\\\n   phase:1, \\\\\n   nolog, \\\\\n   pass, \\\\\n   t:none, \\\\\n   setvar:\'tx.static_extensions='+os.environ['STATIC_EXTENSIONS']+'\'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $STATIC_EXTENSIONS ]; then
+  sed -z -E -i 's|#SecAction.{6}id:900260.*\x27tx\.static_extensions=/[[:lower:][:space:]/.]*\x27\"|SecAction \\\n  \"id:900260, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:\x27tx.static_extensions='"$STATIC_EXTENSIONS"'\x27\"|' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Block request if number of arguments is too high
-$(python <<EOF
-import re
-import os
-if "MAX_NUM_ARGS" in os.environ: 
-   out=re.sub('(#SecAction[\S\s]{6}id:900300[\s\S]*tx\.max_num_args=255\")','SecAction \\\\\n \"id:900300, \\\\\n phase:1, \\\\\n nolog, \\\\\n pass, \\\\\n t:none, \\\\\n setvar:tx.max_num_args='+os.environ['MAX_NUM_ARGS']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $MAX_NUM_ARGS ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900300.*tx\.max_num_args=255\"/SecAction \\\n  \"id:900300, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.max_num_args='"$MAX_NUM_ARGS"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Block request if the length of any argument name is too high
-$(python <<EOF
-import re
-import os
-if "ARG_NAME_LENGTH" in os.environ: 
-   out=re.sub('(#SecAction[\S\s]{6}id:900310[\s\S]*tx\.arg_name_length=100\")','SecAction \\\\\n \"id:900310, \\\\\n phase:1, \\\\\n nolog, \\\\\n pass, \\\\\n t:none, \\\\\n setvar:tx.arg_name_length='+os.environ['ARG_NAME_LENGTH']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $ARG_NAME_LENGTH ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900310.*tx\.arg_name_length=100\"/SecAction \\\n \"id:900310, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.arg_name_length='"$ARG_NAME_LENGTH"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Block request if the length of any argument value is too high
-$(python <<EOF
-import re
-import os
-if "ARG_LENGTH" in os.environ: 
-   out=re.sub('(#SecAction[\S\s]{6}id:900320[\s\S]*tx\.arg_length=400\")','SecAction \\\\\n \"id:900320, \\\\\n phase:1, \\\\\n nolog, \\\\\n pass, \\\\\n t:none, \\\\\n setvar:tx.arg_length='+os.environ['ARG_LENGTH']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $ARG_LENGTH ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900320.*tx\.arg_length=400\"/SecAction \\\n  \"id:900320, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.arg_length='"$ARG_LENGTH"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Block request if the total length of all combined arguments is too high
-$(python <<EOF
-import re
-import os
-if "TOTAL_ARG_LENGTH" in os.environ: 
-   out=re.sub('(#SecAction[\S\s]{6}id:900330[\s\S]*tx\.total_arg_length=64000\")','SecAction \\\\\n \"id:900330, \\\\\n phase:1, \\\\\n nolog, \\\\\n pass, \\\\\n t:none, \\\\\n setvar:tx.total_arg_length='+os.environ['TOTAL_ARG_LENGTH']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $TOTAL_ARG_LENGTH ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900330.*tx\.total_arg_length=64000\"/SecAction \\\n  \"id:900330, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n  t:none, \\\n   setvar:tx.total_arg_length='"$TOTAL_ARG_LENGTH"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Block request if the total length of all combined arguments is too high
-$(python <<EOF
-import re
-import os
-if "MAX_FILE_SIZE" in os.environ: 
-   out=re.sub('(#SecAction[\S\s]{6}id:900340[\s\S]*tx\.max_file_size=1048576\")','SecAction \\\\\n \"id:900340, \\\\\n phase:1, \\\\\n nolog, \\\\\n pass, \\\\\n t:none, \\\\\n setvar:tx.max_file_size='+os.environ['MAX_FILE_SIZE']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $MAX_FILE_SIZE ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900340.*tx\.max_file_size=1048576\"/SecAction \\\n  \"id:900340, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.max_file_size='"$MAX_FILE_SIZE"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 # Block request if the total size of all combined uploaded files is too high
-$(python <<EOF
-import re
-import os
-if "COMBINED_FILE_SIZES" in os.environ: 
-   out=re.sub('(#SecAction[\S\s]{6}id:900350[\s\S]*tx\.combined_file_sizes=1048576\")','SecAction \\\\\n \"id:900350, \\\\\n phase:1, \\\\\n nolog, \\\\\n pass, \\\\\n t:none, \\\\\n setvar:tx.combined_file_sizes='+os.environ['COMBINED_FILE_SIZES']+'\"',open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','r').read())
-   open('/etc/modsecurity.d/owasp-crs/crs-setup.conf','w').write(out)
-EOF
-) && \
+if [ ! -z $COMBINED_FILE_SIZES ]; then
+  sed -z -E -i 's/#SecAction.{6}id:900350.*tx\.combined_file_sizes=1048576\"/SecAction \\\n  \"id:900350, \\\n   phase:1, \\\n   nolog, \\\n   pass, \\\n   t:none, \\\n   setvar:tx.combined_file_sizes='"$COMBINED_FILE_SIZES"'\"/' /etc/modsecurity.d/owasp-crs/crs-setup.conf
+fi 
 
 if [ $WEBSERVER = "Apache" ]; then
   if [ ! -z $PROXY ]; then


### PR DESCRIPTION
Replaced python with sed in entrypoint script.

Fixes: #2

## Feature parity

I did some tests to make sure the content of the file is the same as the previous version.
These are the commands that I ran:

Build the image on the old branch with python:
```console
docker build src -f 3.3-nginx/Dockerfile --tag owasp/modsecurity-crs:old
```
```console
docker run -ti -e PARANOIA=11 \
               -e EXECUTING_PARANOIA=11 \
               -e ENFORCE_BODYPROC_URLENCODED=11 \
               -e ANOMALYIN=11 \
               -e ANOMALYOUT=11 \
               -e ALLOWED_METHODS=11 \
               -e ALLOWED_REQUEST_CONTENT_TYPE=11 \
               -e ALLOWED_REQUEST_CONTENT_TYPE_CHARSET=11 \
               -e ALLOWED_HTTP_VERSIONS=11 \
               -e RESTRICTED_EXTENSIONS=11 \
               -e STATIC_EXTENSIONS=11 \
               -e MAX_NUM_ARGS=11 \
               -e ARG_NAME_LENGTH=11 \
               -e ARG_LENGTH=11 \
               -e TOTAL_ARG_LENGTH=11 \
               -e MAX_FILE_SIZE=11 \
               -e COMBINED_FILE_SIZES=11 \
               -e RESTRICTED_HEADERS=11 \
               --rm owasp/modsecurity:1 \
               cat /etc/modsecurity.d/owasp-crs/crs-setup.conf > test_old.txt
```

Build the image on the new branch with sed:
```console
docker build src -f 3.3-nginx/Dockerfile --tag owasp/modsecurity-crs:new
```
```console
docker run -ti -e PARANOIA=11 \
               -e EXECUTING_PARANOIA=11 \
               -e ENFORCE_BODYPROC_URLENCODED=11 \
               -e ANOMALYIN=11 \
               -e ANOMALYOUT=11 \
               -e ALLOWED_METHODS=11 \
               -e ALLOWED_REQUEST_CONTENT_TYPE=11 \
               -e ALLOWED_REQUEST_CONTENT_TYPE_CHARSET=11 \
               -e ALLOWED_HTTP_VERSIONS=11 \
               -e RESTRICTED_EXTENSIONS=11 \
               -e STATIC_EXTENSIONS=11 \
               -e MAX_NUM_ARGS=11 \
               -e ARG_NAME_LENGTH=11 \
               -e ARG_LENGTH=11 \
               -e TOTAL_ARG_LENGTH=11 \
               -e MAX_FILE_SIZE=11 \
               -e COMBINED_FILE_SIZES=11 \
               -e RESTRICTED_HEADERS=11 \
               --rm owasp/modsecurity:1 \
               cat /etc/modsecurity.d/owasp-crs/crs-setup.conf > test_after.txt
```

Test the contents ignoring spaces:
```console
diff -w test_new.txt test_old.txt
```

P.S. In the old config file the identation for SecAction 900300, 900310, 900320, 9003030, 900340, 900350 were wrong. It can be seen by running the following command:
```console
diff test_new.txt test_old.txt
```
