### PR TITLE
Add env variables to nginx

### DIFF
--- a/3.3-nginx/Dockerfile
+++ b/3.3-nginx/Dockerfile
@@ -5,15 +5,38 @@ LABEL maintainer="Chaim Sanders <chaim.sanders@gmail.com>"
 ARG COMMIT=v3.3/dev
 ARG BRANCH=v3.3/dev
 ARG REPO=SpiderLabs/owasp-modsecurity-crs
-ENV PARANOIA=1
-ENV ANOMALY_INBOUND=5
-ENV ANOMALY_OUTBOUND=4
+
+ENV PARANOIA=1 \
+    ANOMALY_INBOUND=5 \
+    ANOMALY_OUTBOUND=4 \
+    NGINX_KEEPALIVE_TIMEOUT=60s \
+    ERRORLOG=/var/log/nginx/error.log \
+    LOGLEVEL=warn \
+    USER=nginx \
+    PORT=80 \
+    SERVERNAME=locahost \
+    WORKER_CONNECTIONS=1024 \
+    MODSEC_RULE_ENGINE=on \
+    MODSEC_REQ_BODY_ACCESS=on \
+    MODSEC_REQ_BODY_LIMIT=13107200 \
+    MODSEC_REQ_BODY_NOFILES_LIMIT=131072 \
+    MODSEC_RESP_BODY_ACCESS=on \
+    MODSEC_RESP_BODY_LIMIT=1048576 \
+    MODSEC_PCRE_MATCH_LIMIT=100000 \
+    MODSEC_PCRE_MATCH_LIMIT_RECURSION=100000
+
+COPY 3.3-nginx/docker-entrypoint.sh /
+COPY 3.3-nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+COPY 3.3-nginx/nginx.conf /etc/nginx/nginx.conf
+COPY src/opt/modsecurity/activate-rules.sh /opt/modsecurity/
+COPY src/etc/modsecurity.d/*.conf /etc/modsecurity.d/
 
 RUN apt-get update \
  && apt-get -y install \
       ca-certificates \
       git \
       iproute2 \
+      moreutils \
  && mkdir /opt/owasp-crs \
  && cd /opt/owasp-crs \
  && git init \
@@ -21,16 +44,7 @@ RUN apt-get update \
  && git fetch --depth 1 origin ${BRANCH} \
  && git checkout ${COMMIT} \
  && mv -v crs-setup.conf.example crs-setup.conf \
- && ln -sv /opt/owasp-crs /etc/modsecurity.d/ \
- && echo 'Include /etc/modsecurity.d/owasp-crs/crs-setup.conf' > /etc/modsecurity.d/include.conf \
- && echo 'Include /etc/modsecurity.d/owasp-crs/rules/*.conf'  >> /etc/modsecurity.d/include.conf \
- && sed -i /etc/modsecurity.d/modsecurity.conf \
-      -e 's/SecRuleEngine DetectionOnly/SecRuleEngine On/g'
-
-COPY 3.3-nginx/docker-entrypoint.sh /
-COPY src/opt/modsecurity/activate-rules.sh /opt/modsecurity/
-
-EXPOSE 80
+ && ln -sv /opt/owasp-crs /etc/modsecurity.d/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/3.3-nginx/conf.d/default.conf
+++ b/3.3-nginx/conf.d/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen ${PORT};
+    server_name ${SERVERNAME};
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}

--- a/3.3-nginx/docker-entrypoint.sh
+++ b/3.3-nginx/docker-entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+ENV_VARIABLES=$(awk 'BEGIN{for(v in ENVIRON) print "$"v}')
+
+for FILE in etc/nginx/nginx.conf etc/nginx/conf.d/default.conf etc/modsecurity.d/modsecurity-override.conf
+do
+    envsubst "$ENV_VARIABLES" <$FILE | sponge $FILE
+done
+
 source /opt/modsecurity/activate-rules.sh
 
 exec "$@"

--- a/3.3-nginx/nginx.conf
+++ b/3.3-nginx/nginx.conf
@@ -1,0 +1,32 @@
+load_module modules/ngx_http_modsecurity_module.so;
+
+user ${USER};
+worker_processes 1;
+
+error_log ${ERRORLOG} ${LOGLEVEL};
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections ${WORKER_CONNECTIONS};
+}
+
+http {
+
+    modsecurity on;
+    modsecurity_rules_file /etc/modsecurity.d/setup.conf;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+
+    keepalive_timeout ${NGINX_KEEPALIVE_TIMEOUT};
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ The following environment variables are available to configure the CRS container
 | MAX_FILE_SIZE | An integer indicating the max_file_size (Default: unlimited) |
 | COMBINED_FILE_SIZES | An integer indicating the combined_file_sizes (Default: unlimited) |
 | APACHE_TIMEOUT | Apache integer value indicating the number of seconds before receiving and sending time out (Default: 60) |
-| LOGLEVEL | Apache string value controlling the number of messages logged to the error_log, Apache (Default: warn) |
-| ERRORLOG | Apache string value indicating the location of the error log file (Default: '/proc/self/fd/2') |
-| PORT | Apache integer value indicating the port where Apache is listening to (Default: 80) |
-| USER | Apache string value indicating the name (or #number) of the user to run httpd as (Default: daemon) |
+| NGINX_KEEPALIVE_TIMEOUT | Nginx integer value indicating the number of seconds a keep-alive client connection will stay open on the server side (Default: 60) |
+| LOGLEVEL | A string value controlling the number of messages logged to the error_log (Default: warn) |
+| ERRORLOG | A string value indicating the location of the error log file (Default: '/proc/self/fd/2') |
+| PORT | An integer value indicating the port where the webserver is listening to (Default: 80) |
+| USER | A string value indicating the name (or #number) of the user to run httpd as (Default: daemon) |
 | GROUP | Apache string value indicating the name (or #number) of the group to run httpd as (Default: daemon) |
-| SERVERADMIN | Apache string value indicating the address where problems with the server should be e-mailed (Default: root@localhost) |
-| SERVERNAME | Apache string value indicating the server name (Default: localhost) |
+| SERVERADMIN | A string value indicating the address where problems with the server should be e-mailed (Default: root@localhost) |
+| SERVERNAME | A string value indicating the server name (Default: localhost) |
 | MODSEC_RULE_ENGINE | ModSecurity string value enabling ModSecurity itself (Default: on) |
 | MODSEC_REQ_BODY_ACCESS | ModSecurity string value allowing ModSecurity to access request bodies (Default: on) |
 | MODSEC_REQ_BODY_LIMIT | ModSecurity integer value indicating the maximum request body size  accepted for buffering (Default: 13107200) |

--- a/src/etc/modsecurity.d/modsecurity-override.conf
+++ b/src/etc/modsecurity.d/modsecurity-override.conf
@@ -6,7 +6,6 @@ SecRequestBodyAccess ${MODSEC_REQ_BODY_ACCESS}
 
 SecRequestBodyLimit ${MODSEC_REQ_BODY_LIMIT}
 SecRequestBodyNoFilesLimit ${MODSEC_REQ_BODY_NOFILES_LIMIT}
-SecRequestBodyInMemoryLimit 131072
 SecRequestBodyLimitAction Reject
 
 SecPcreMatchLimit ${MODSEC_PCRE_MATCH_LIMIT}


### PR DESCRIPTION
Added the following env variables to the Nginx image:

* NGINX_KEEPALIVE_TIMEOUT
* ERRORLOG
* LOGLEVEL
* USER
* PORT
* SERVERNAME
* WORKER_CONNECTIONS
* MODSEC_RULE_ENGINE
* MODSEC_REQ_BODY_ACCESS
* MODSEC_REQ_BODY_LIMIT
* MODSEC_REQ_BODY_NOFILES_LIMIT
* MODSEC_RESP_BODY_ACCESS
* MODSEC_RESP_BODY_LIMIT
* MODSEC_PCRE_MATCH_LIMIT
* MODSEC_PCRE_MATCH_LIMIT_RECURSION

Since the Nginx does not recognise the env variables in the conf files, I used `envsubst` in the entrypoint script.